### PR TITLE
skip chr if not in rmsk

### DIFF
--- a/irescue/main.py
+++ b/irescue/main.py
@@ -64,7 +64,7 @@ def main():
                        outname='rmsk.bed')
 
     # get list of reference names from bam
-    chrNames = getRefs(args.bam)
+    chrNames = getRefs(args.bam, args.regions)
 
     # decompress whitelist if compressed
     whitelist = prepare_whitelist(args.whitelist, args.tmpdir)

--- a/irescue/map.py
+++ b/irescue/map.py
@@ -91,12 +91,22 @@ def prepare_whitelist(whitelist, tmpdir):
     return whitelist
 
 # Get list of reference names from BAM file, skipping those without reads.
-def getRefs(bamFile):
+def getRefs(bamFile, bedFile):
     chrNames = list()
     for line in idxstats(bamFile).strip().split('\n'):
         l = line.strip().split('\t')
         if int(l[2])>0:
             chrNames.append(l[0])
+    bedChrNames = set()
+    if testGz(bedFile):
+        with gzopen(bedFile, 'rb') as f:
+            for line in f:
+                bedChrNames.add(line.decode().split('\t')[0])
+    else:
+        with open(bedFile, 'r') as f:
+            for line in f:
+                bedChrNames.add(line.split('\t')[0])
+    chrNames = [x for x in chrNames if x in bedChrNames]
     return chrNames
 
 # Intersect reads with repeatmasker regions. Return the intersection file path.

--- a/irescue/map.py
+++ b/irescue/map.py
@@ -106,7 +106,10 @@ def getRefs(bamFile, bedFile):
         with open(bedFile, 'r') as f:
             for line in f:
                 bedChrNames.add(line.split('\t')[0])
-    chrNames = [x for x in chrNames if x in bedChrNames]
+    skipChr = [x for x in chrNames if x not in bedChrNames]
+    if skipChr:
+        writerr('WARNING: The following references are not present in the TE annotation and will be skipped: ' + ', '.join(skipChr))
+        chrNames = [x for x in chrNames if x in bedChrNames]
     return chrNames
 
 # Intersect reads with repeatmasker regions. Return the intersection file path.


### PR DESCRIPTION
Skip intersect if mapped chromosome is not in repeatmasker. Will speed up multiprocess pooling.